### PR TITLE
Typo fix in Lab 3 Selective Excitation.ipynb

### DIFF
--- a/courses/MRI Fundamentals/Lab 3/Lab 3 Selective Excitation.ipynb
+++ b/courses/MRI Fundamentals/Lab 3/Lab 3 Selective Excitation.ipynb
@@ -113,7 +113,7 @@
    "metadata": {},
    "source": [
     "<center><img src=\"Images/projection.png\" width=\"1300\"></center>\n",
-    "<center><figcaption style=\"width: 600px;\">Figure 1: Setting the frequency and phase encoding in the x and z axes produces a projection image where the varying signal components in the y direction are summed into average values.  </figcaption></center>\n"
+    "<center><figcaption style=\"width: 600px;\">Figure 1: Setting the frequency and phase encoding in the x and y axes produces a projection image where the varying signal components in the z direction are summed into average values.  </figcaption></center>\n"
    ]
   },
   {


### PR DESCRIPTION
I think description of axes is swapped in Fig 1 of Lab 3